### PR TITLE
Integrate money hud

### DIFF
--- a/scenes/MoneyHUD.tscn
+++ b/scenes/MoneyHUD.tscn
@@ -5,16 +5,16 @@
 [ext_resource type="Texture2D" uid="uid://bdbtglxjaliah" path="res://assets/images/sprites/psyche_logo.png" id="2_6hkma"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_k0qt1"]
-bg_color = Color(0.06666667, 0.06666667, 0.06666667, 0.33333334)
+bg_color = Color(0.15, 0.15, 0.2, 0.95)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.827451, 0.827451, 0.827451, 1)
-corner_radius_top_left = 8
-corner_radius_top_right = 8
-corner_radius_bottom_right = 8
-corner_radius_bottom_left = 8
+border_color = Color(0.4, 0.4, 0.5, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
 
 [node name="HUDRoot" type="Control"]
 layout_mode = 3
@@ -30,10 +30,10 @@ layout_mode = 1
 anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = -120.0
-offset_right = 200.0
-offset_bottom = -10.0
+offset_left = 8.0
+offset_top = -118.0
+offset_right = 198.0
+offset_bottom = -8.0
 grow_vertical = 0
 theme_override_styles/panel = SubResource("StyleBoxFlat_k0qt1")
 

--- a/scenes/MoneyHUD.tscn
+++ b/scenes/MoneyHUD.tscn
@@ -27,12 +27,14 @@ script = ExtResource("1_k0qt1")
 
 [node name="Panel" type="Panel" parent="."]
 layout_mode = 1
-anchors_preset = 1
-anchor_left = 1.0
-anchor_right = 1.0
-offset_left = -320.0
-offset_bottom = 110.0
-grow_horizontal = 0
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 10.0
+offset_top = -120.0
+offset_right = 200.0
+offset_bottom = -10.0
+grow_vertical = 0
 theme_override_styles/panel = SubResource("StyleBoxFlat_k0qt1")
 
 [node name="ContentMargin" type="MarginContainer" parent="Panel"]

--- a/scripts/core/board.gd
+++ b/scripts/core/board.gd
@@ -15,6 +15,10 @@ var space_info_panel: CanvasLayer = null
 const DiceRollPanelScene = preload("res://scenes/DiceRollPanel.tscn")
 var dice_roll_ui: Control = null
 
+# Money HUD reference and scene
+const MoneyHUDScene = preload("res://scenes/MoneyHUD.tscn")
+var money_hud: Control = null
+
 # Mouse interaction state
 var hovered_tile: Vector2i = Vector2i(-1, -1)
 var selected_tile: Vector2i = Vector2i(-1, -1)
@@ -46,6 +50,9 @@ func _ready() -> void:
 	# Instantiate the dice roll UI
 	_setup_dice_roll_ui()
 	
+	# Instantiate the money HUD
+	_setup_money_hud()
+	
 	# Connect piece's space_changed signal to update the panel (only when no tile selected)
 	if space_info_panel:
 		piece.space_changed.connect(_on_piece_space_changed)
@@ -72,6 +79,20 @@ func _setup_dice_roll_ui() -> void:
 	
 	# Connect the dice_rolled signal to move the piece
 	dice_roll_ui.dice_rolled.connect(_on_dice_rolled)
+
+
+func _setup_money_hud() -> void:
+	# Create a CanvasLayer to hold the money HUD (ensures it's always on top)
+	var canvas_layer = CanvasLayer.new()
+	canvas_layer.name = "MoneyHUDLayer"
+	canvas_layer.layer = 9  # Just below dice UI layer
+	
+	# Instantiate the money HUD
+	money_hud = MoneyHUDScene.instantiate()
+	canvas_layer.add_child(money_hud)
+	
+	# Add to scene tree
+	get_tree().root.call_deferred("add_child", canvas_layer)
 
 
 func _initial_panel_update() -> void:


### PR DESCRIPTION
This pull request introduces the Money HUD to the game board scene, ensuring it is properly instantiated and displayed above most UI layers. The key changes include adding the Money HUD scene reference, updating the board script to instantiate and display the HUD, and adjusting the Money HUD panel's appearance and layout for better integration with the UI.

**Money HUD integration:**
* Added a reference to `MoneyHUD.tscn` and a variable for `money_hud` in `board.gd`, enabling the board to manage the Money HUD instance.
* Implemented `_setup_money_hud()` in `board.gd` to instantiate the Money HUD inside a new `CanvasLayer` for proper layering, and called this setup in `_ready()`. [[1]](diffhunk://#diff-59a250055833101f41885d3fd14e1d9571b7ddaa98694fdc2be3583ae667ecd3R53-R55) [[2]](diffhunk://#diff-59a250055833101f41885d3fd14e1d9571b7ddaa98694fdc2be3583ae667ecd3R84-R97)

**UI/UX improvements:**
* Updated the background and border colors, as well as the corner radius, of the Money HUD panel in `MoneyHUD.tscn` for better visual clarity and consistency.
* Adjusted the layout and anchoring of the Money HUD panel in `MoneyHUD.tscn` to ensure correct positioning and sizing within the UI.