### PR TITLE
Rent

### DIFF
--- a/scripts/core/board.gd
+++ b/scripts/core/board.gd
@@ -665,7 +665,7 @@ func _on_dice_rolled(d1: int, d2: int, total: int, is_doubles: bool) -> void:
 			if is_doubles:
 				current_player.doubles_count += 1
 			# Notify that player has rolled
-			GameState.player_rolled.emit(current_player)
+			GameState.player_rolled.emit(current_player, total)
 
 
 func _clear_pieces() -> void:

--- a/scripts/core/game_state.gd
+++ b/scripts/core/game_state.gd
@@ -29,7 +29,7 @@ signal turn_started(player_index: int)
 signal turn_ended(player_index: int)
 
 ## Emitted when a player rolls the dice
-signal player_rolled(player: PlayerState)
+signal player_rolled(player: PlayerState, total: int)
 
 ## Emitted when a player completes an action (purchase, pay, etc.)
 signal action_completed()
@@ -66,6 +66,8 @@ var player_count: int = 6
 # Holds the player state data models
 var players: Array[PlayerState] = []
 
+var lastRoll = 0
+
 # Player colors for pieces and UI
 const PLAYER_COLORS: Array[Color] = [
 	Color(0.9, 0.2, 0.2),   # Red
@@ -95,6 +97,7 @@ var setup_human_count: int = 1
 func _ready() -> void:
 	pay_rent.connect(_pay_rent)
 	purchase_property.connect(_purchase_property)
+	player_rolled.connect(_updateLastRoll)
 
 	_setup_board()
 	# Don't call _setup_players() here.
@@ -201,18 +204,21 @@ func _purchase_owned_property(property: Ownable, buyer: int, seller: int, purcha
 	transfer(buyer, seller, purchase_price, "purchase owned")
 	_transfer_property(property, buyer)
 
-## Returns the numner of instrument spaces owned by the player
-func _checkOwnedInstruments(player: int) -> int:
-	var instruments = 0;
+## Returns the numner of instrument or planet spaces owned by the player
+func _checkSimilarProperties(property: Ownable) -> int:
+	var properties = 0;
 	for i in range(board.size()):
-		print("check space ", i)
-		if board[i].get_script().get_global_name() == "InstrumentSpace":
-			print("check player on space ", i, "player is ", board[i]._player_owner, "player we are looking for is ", player)
-			if board[i]._is_owned && board[i]._player_owner == player:
-				instruments += 1
-	return instruments
-			
+		if board[i].get_script().get_global_name() == property.get_script().get_global_name():
+			if board[i]._is_owned && board[i]._player_owner == property._player_owner:
+				properties += 1
+	return properties
 
+## Returns the numner of instrument spaces owned by the player
+
+
+	
+func _updateLastRoll(player: PlayerState, total: int):
+	lastRoll = total
 
 func _pay_rent(property: Ownable, player: int) -> void:
 	if !property._is_owned or property._player_owner == player:
@@ -236,8 +242,8 @@ func _pay_rent(property: Ownable, player: int) -> void:
 					rent = property._discovery_rent
 				_:
 					rent = 0
-		"InstrumentSpace": # TODO: Implement checking for number of instrument spaces
-			var instruments = _checkOwnedInstruments(property._player_owner)
+		"InstrumentSpace": 
+			var instruments = _checkSimilarProperties(property)
 			match instruments:
 				1: 
 					rent = property._default_rent
@@ -249,8 +255,15 @@ func _pay_rent(property: Ownable, player: int) -> void:
 					rent = property._four_instrument_rent
 				_:
 					rent = 0
-		"PlanetSpace": # TODO: Implement checking dice roll for determining rent
-			rent = 0
+		"PlanetSpace":
+			var planets = _checkSimilarProperties(property)
+			match planets:
+				1:
+					rent = property._default_multiplier * lastRoll
+				2:
+					rent = property._two_planet_multiplier * lastRoll
+				_:
+					rent = 0
 
 	transfer(player, property._player_owner, rent, "rent")
 

--- a/scripts/core/game_state.gd
+++ b/scripts/core/game_state.gd
@@ -66,7 +66,7 @@ var player_count: int = 6
 # Holds the player state data models
 var players: Array[PlayerState] = []
 
-var lastRoll = 0
+var last_roll = 0
 
 # Player colors for pieces and UI
 const PLAYER_COLORS: Array[Color] = [
@@ -97,7 +97,7 @@ var setup_human_count: int = 1
 func _ready() -> void:
 	pay_rent.connect(_pay_rent)
 	purchase_property.connect(_purchase_property)
-	player_rolled.connect(_updateLastRoll)
+	player_rolled.connect(_update_last_roll)
 
 	_setup_board()
 	# Don't call _setup_players() here.
@@ -205,7 +205,7 @@ func _purchase_owned_property(property: Ownable, buyer: int, seller: int, purcha
 	_transfer_property(property, buyer)
 
 ## Returns the numner of instrument or planet spaces owned by the player
-func _checkSimilarProperties(property: Ownable) -> int:
+func _check_similar_properties(property: Ownable) -> int:
 	var properties = 0;
 	for i in range(board.size()):
 		if board[i].get_script().get_global_name() == property.get_script().get_global_name():
@@ -213,12 +213,8 @@ func _checkSimilarProperties(property: Ownable) -> int:
 				properties += 1
 	return properties
 
-## Returns the numner of instrument spaces owned by the player
-
-
-	
-func _updateLastRoll(player: PlayerState, total: int):
-	lastRoll = total
+func _update_last_roll(player: PlayerState, total: int):
+	last_roll = total
 
 func _pay_rent(property: Ownable, player: int) -> void:
 	if !property._is_owned or property._player_owner == player:
@@ -243,7 +239,7 @@ func _pay_rent(property: Ownable, player: int) -> void:
 				_:
 					rent = 0
 		"InstrumentSpace": 
-			var instruments = _checkSimilarProperties(property)
+			var instruments = _check_similar_properties(property)
 			match instruments:
 				1: 
 					rent = property._default_rent
@@ -256,12 +252,12 @@ func _pay_rent(property: Ownable, player: int) -> void:
 				_:
 					rent = 0
 		"PlanetSpace":
-			var planets = _checkSimilarProperties(property)
+			var planets = _check_similar_properties(property)
 			match planets:
 				1:
-					rent = property._default_multiplier * lastRoll
+					rent = property._default_multiplier * last_roll
 				2:
-					rent = property._two_planet_multiplier * lastRoll
+					rent = property._two_planet_multiplier * last_roll
 				_:
 					rent = 0
 

--- a/scripts/core/game_state.gd
+++ b/scripts/core/game_state.gd
@@ -201,6 +201,18 @@ func _purchase_owned_property(property: Ownable, buyer: int, seller: int, purcha
 	transfer(buyer, seller, purchase_price, "purchase owned")
 	_transfer_property(property, buyer)
 
+## Returns the numner of instrument spaces owned by the player
+func _checkOwnedInstruments(player: int) -> int:
+	var instruments = 0;
+	for i in range(board.size()):
+		print("check space ", i)
+		if board[i].get_script().get_global_name() == "InstrumentSpace":
+			print("check player on space ", i, "player is ", board[i]._player_owner, "player we are looking for is ", player)
+			if board[i]._is_owned && board[i]._player_owner == player:
+				instruments += 1
+	return instruments
+			
+
 
 func _pay_rent(property: Ownable, player: int) -> void:
 	if !property._is_owned or property._player_owner == player:
@@ -225,7 +237,18 @@ func _pay_rent(property: Ownable, player: int) -> void:
 				_:
 					rent = 0
 		"InstrumentSpace": # TODO: Implement checking for number of instrument spaces
-			rent = 0
+			var instruments = _checkOwnedInstruments(property._player_owner)
+			match instruments:
+				1: 
+					rent = property._default_rent
+				2:
+					rent = property._two_instrument_rent
+				3:
+					rent = property._three_instrument_rent
+				4:
+					rent = property._four_instrument_rent
+				_:
+					rent = 0
 		"PlanetSpace": # TODO: Implement checking dice roll for determining rent
 			rent = 0
 

--- a/scripts/ui/space_action_popup.gd
+++ b/scripts/ui/space_action_popup.gd
@@ -87,7 +87,11 @@ func show_actions(space_num: int) -> void:
 				else:
 					description = "You landed on %s." % space_info.name
 			elif property is Ownable and property._is_owned:
-				description = "You landed on %s. It is owned by Player %d." % [space_info.name, property._player_owner + 1]
+				if property._player_owner == GameState.current_player_index:
+					description = "You landed on %s. You own this property." % [space_info.name]
+				else:
+					description = "You landed on %s. It is owned by Player %d." % [space_info.name, property._player_owner + 1]
+					can_pay = true
 			else:
 				description = "You landed on %s." % space_info.name
 		"cost":


### PR DESCRIPTION
Implement rent for all 3 property types. Update space land logic so you only pay if you land on a space you don 't own. Gamestate keeps track of the most recent die roll to use for planet rent calculations. 